### PR TITLE
제목 : 알림기능 개선 및 특정 컴포넌트 css수정

### DIFF
--- a/src/components/DetailPage/CreateGroupModal.jsx
+++ b/src/components/DetailPage/CreateGroupModal.jsx
@@ -133,13 +133,14 @@ const CreateGroupModal = ({ close }) => {
         </div>
         <form onSubmit={createGroupForm}>
           <div className="my-3 mx-3 flex flex-col gap-2">
-            {inputFields.map((field) =>
+            {inputFields.map((field,index) =>
               field.type === 'select' ? (
                 <Select
                   options={exercises.map((sport) => ({ label: sport, value: sport }))}
                   placeholder="스포츠명 선택"
                   onChange={(selected) => setFormData((prev) => ({ ...prev, sportsName: selected.value }))}
                   className="text-xs"
+                  key={index}
                 />
               ) : field.type === 'checkbox' ? (
                 <label key={field.name} className="flex items-center gap-2">
@@ -149,6 +150,7 @@ const CreateGroupModal = ({ close }) => {
                     checked={formData[field.name]}
                     onChange={handleInputChange}
                     autoComplete="off"
+                    key={index}
                   />
                   <span className="text-xs font-semibold">{field.placeholder}</span>
                 </label>

--- a/src/components/myPage/ClubInfo.jsx
+++ b/src/components/myPage/ClubInfo.jsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import styled from 'styled-components';
 import Loading from '../GatheringPage/Loading';
 import dayjs from 'dayjs';
-const ClubInfo = ({ placeID }) => {
+const ClubInfo = ({ placeID, status }) => {
   const MyClubLists = async () => {
     const { data: mylist, error } = await supabase
       .from('Places')
@@ -16,7 +16,6 @@ const ClubInfo = ({ placeID }) => {
 
     return mylist;
   };
-
   const {
     data: theClubs,
     isPending,
@@ -55,12 +54,19 @@ const ClubInfo = ({ placeID }) => {
     <>
       <div className="p-4 min-h-35 border border-sky-100 cursor-pointer min-h-35   rounded-lg mb-5 hover:shadow-xl transition-all duration-300 ease-in-out">
         <div className="flex justify-between items-center">
-          <div className="bg-[#efefef] rounded-md px-3 py-2 text-center text-sm">{theClubs[0].sports_name}</div>
+          <div className="bg-[#efefef] rounded-md px-3 py-2 box-border text-center w-2/5 text-xs">
+            {theClubs[0].sports_name}
+          </div>
           <STDeadline $status={$status}>{theClubs[0].deadline}</STDeadline>
         </div>
-        <div className="flex flex-col">
-          <div className="pb-2 text-base mt-4 font-black truncate">{theClubs[0].gather_name}</div>
-          <div className="text-sm">{theClubs[0].region}</div>
+        <div className="flex justify-between items-center">
+          <div className="flex flex-col text-xs">
+            <p className="pb-2 mt-4 font-black truncate">{theClubs[0].gather_name}</p>
+            <p>{theClubs[0].region}</p>
+          </div>
+          <ApprovalResults $status={status}>
+            {status === 'rejected' ? '승인거절' : status === 'pending' ? '승인대기' : '가입완료'}
+          </ApprovalResults>
         </div>
       </div>
     </>
@@ -68,15 +74,15 @@ const ClubInfo = ({ placeID }) => {
 };
 
 export const STDeadline = styled.div`
-  max-width: 120px;
+  max-width: 50%;
   height: min-content;
-  padding: 8px 10px;
+  padding: 0.5rem 0.75rem;
   border-radius: 5px;
   color: white;
-  font-weight: bold;
-  font-size: 0.875rem;
-  line-height: 1.25rem;
+  font-size: 0.75rem;
+  line-height: 1rem;
   text-align: center;
+  box-sizing: border-box;
   @media screen and (max-width: 1024px) {
     width: 100%;
   }
@@ -87,6 +93,30 @@ export const STDeadline = styled.div`
       case 'dayToday':
         return '#b1c3f2';
       case 'dayPast':
+        return '#f7a9a9';
+      default:
+        return 'gray';
+    }
+  }};
+`;
+
+export const ApprovalResults = styled.p`
+  max-width: 50%;
+  height: min-content;
+  padding: 0.5rem;
+  border-radius: 5px;
+  color: white;
+  font-size: 0.75rem;
+  line-height: 1rem;
+  text-align: center;
+  box-sizing: border-box;
+  background-color: ${({ $status }) => {
+    switch ($status) {
+      case 'approved':
+        return '#82C0F9';
+      case 'peding':
+        return '#b1c3f2';
+      case 'rejected':
         return '#f7a9a9';
       default:
         return 'gray';

--- a/src/components/myPage/ClubList.jsx
+++ b/src/components/myPage/ClubList.jsx
@@ -9,6 +9,8 @@ import { STSection } from './MyPage';
 import { useEffect, useState } from 'react';
 import dayjs from 'dayjs';
 const ClubList = () => {
+  const [activeTab, setActiveTab] = useState('joined');
+
   const navigate = useNavigate();
   const [userId, setUserData] = useState(null);
   const getMyGathering = async () => {
@@ -105,82 +107,80 @@ const ClubList = () => {
       }
     });
   };
-
   return (
     <>
       <STSection>
         <h3 className="flex gap-2 mt-2 text-xl items-center">
           <RiGroupLine />내 번개 모임
         </h3>
-        <div className="min-[320px]:block min-[320px]:mb-[10%] sm:mb-0 lg:flex justify-between gap-5">
-          {/* 내가 가입한 모임 */}
-          <div className="flex flex-col gap-4 w-full">
-            {theGatherings && theGatherings.length > 0 ? (
-              <ul className="truncate">
-                <span className="flex border-b-2 border-slate-300 mb-5 text-xs items-center pb-2">
-                  <AiFillThunderbolt />
-                  내가 가입한 번개
-                </span>
-                {theGatherings.map(({ place_id }, index) => (
-                  <li key={index + 1} onClick={() => handleMoveToDetail(place_id)} className="cursor-pointer truncate">
-                    <ClubInfo placeID={place_id} />
-                  </li>
-                ))}
-              </ul>
-            ) : (
-              <div className="flex flex-col gap-4 w-full">
-                <span className="flex border-b-2 border-slate-300 mb-5 text-xs items-center pb-2">
-                  <AiFillThunderbolt />
-                  내가 가입한 번개
-                </span>
-                <div className="flex mx-auto text-slate-400 items-center">
-                  가입한 번개 <AiFillThunderbolt /> 모임이 없어요!
-                </div>
-              </div>
-            )}
-          </div>
-          {/* 내가 만든 모임 */}
-          <div className="flex flex-col gap-4 w-full">
-            {MyCreateGathering && MyCreateGathering.length > 0 ? (
-              <ul>
-                <span className="flex border-b-2 border-slate-300 mb-5 text-xs items-center pb-2">
-                  <AiOutlineThunderbolt />
-                  내가 만든 번개
-                </span>
-                {MyCreateGatheringWithStatus.map(
-                  ({ region, sports_name, gather_name, deadline, id, $status }, index) => (
-                    <li
-                      key={index + 1}
-                      onClick={() => handleMoveToDetail(id)}
-                      className="cursor-pointer p-4 min-h-35 border border-teal-100 rounded-lg mb-5 hover:shadow-xl transition-all duration-300 ease-in-out"
-                    >
-                      <div className="flex justify-between items-center">
-                        <div className="bg-[#efefef] rounded-md px-3 py-2 text-center w-[120px] text-sm">
-                          {sports_name}
-                        </div>
-                        <STDeadline $status={$status}>{deadline}</STDeadline>
-                      </div>
-                      <div className="flex flex-col">
-                        <div className="pb-2 text-base mt-4 font-black truncate">{gather_name}</div>
-                        <div className="text-sm">{region}</div>
-                      </div>
-                    </li>
-                  )
-                )}
-              </ul>
-            ) : (
-              <div className="flex flex-col gap-4">
-                <span className="flex border-b-2 border-slate-300 mb-5 text-xs items-center pb-2">
-                  <AiOutlineThunderbolt />
-                  내가 만든 번개
-                </span>
-                <div className="flex mx-auto text-slate-400 items-center">
-                  만든 번개 <AiOutlineThunderbolt /> 모임이 없어요!
-                </div>
-              </div>
-            )}
-          </div>
+        <div className="flex mb-5 box-border w-full">
+          <button
+            className={`px-5 py-2 w-1/2 text-sm font-bold transition-all border-b-2 ${
+              activeTab === 'joined'
+                ? 'border-blue-500 text-blue-500 bg-customBackground rounded-t-xl'
+                : 'text-gray-400'
+            }`}
+            onClick={() => setActiveTab('joined')}
+          >
+            <AiFillThunderbolt className="inline-block mr-1" />
+            가입한 번개
+          </button>
+          <button
+            className={`px-5 py-2 w-1/2 text-sm font-bold transition-all border-b-2 ${
+              activeTab === 'created'
+                ? ' border-blue-500 text-blue-500 bg-customBackground rounded-t-xl'
+                : 'text-gray-400'
+            }`}
+            onClick={() => setActiveTab('created')}
+          >
+            <AiOutlineThunderbolt className="inline-block mr-1" />
+            만든 번개
+          </button>
         </div>
+        {activeTab === 'joined' ? (
+          // 내가 가입한 번개 리스트
+          theGatherings && theGatherings.length > 0 ? (
+            <ul className="truncate flex items-center flex-wrap gap-2">
+              {theGatherings.map(({ place_id, status }, index) => (
+                <li
+                  key={index + 1}
+                  onClick={() => handleMoveToDetail(place_id)}
+                  className="cursor-pointer truncate flex-auto"
+                >
+                  <ClubInfo placeID={place_id} status={status} />
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="flex mx-auto text-slate-400 items-center">
+              가입한 번개 <AiFillThunderbolt /> 모임이 없어요!
+            </div>
+          )
+        ) : // 내가 만든 번개 리스트
+        MyCreateGathering && MyCreateGathering.length > 0 ? (
+          <ul className="flex items-center flex-wrap gap-2">
+            {MyCreateGatheringWithStatus.map(({ region, sports_name, gather_name, deadline, id, $status }, index) => (
+              <li
+                key={index + 1}
+                onClick={() => handleMoveToDetail(id)}
+                className="cursor-pointer p-4 border border-teal-100 rounded-lg hover:shadow-xl  flex-auto"
+              >
+                <div className="flex justify-between items-center">
+                  <div className="bg-[#efefef] rounded-md px-3 py-2 text-center w-2/5 text-xs">{sports_name}</div>
+                  <STDeadline $status={$status}>{deadline}</STDeadline>
+                </div>
+                <div className="flex flex-col text-xs">
+                  <p className="pb-2 mt-4 font-black truncate">{gather_name}</p>
+                  <p>{region}</p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div className="flex mx-auto text-slate-400 items-center">
+            만든 번개 <AiOutlineThunderbolt /> 모임이 없어요!
+          </div>
+        )}
       </STSection>
     </>
   );

--- a/src/components/myPage/MyPage.jsx
+++ b/src/components/myPage/MyPage.jsx
@@ -4,8 +4,8 @@ import UserInfo from './UserInfo';
 
 const MyPage = () => {
   return (
-    <section className="max-w-screen-xl flex flex-col mx-auto lg:w-[75%] lg:mx-auto md:w-[75%] md:mx-0px auto; md:ml-[110px]  sm:w-[80%] sm:mx-auto sm:ml-[100px] min-[320px]:w-[80%]">
-      <div className="flex flex-col p-2 gap-1 w-full sm:p-1 mx-auto md:p-4 ">
+    <section className="max-w-screen-xl flex flex-col mx-auto lg:w-[75%] lg:mx-auto md:w-[75%] md:mx-0px auto; md:ml-[110px]  sm:w-[80%] sm:mx-auto sm:ml-[100px] min-[320px]:w-[80%] h-[100dvh] ">
+      <div className="flex flex-col p-2 gap-1 w-full sm:p-1 mx-auto md:p-4 pb-[5rem]">
         <UserInfo />
         <ClubList />
       </div>
@@ -19,6 +19,7 @@ export const STSection = styled.section`
   padding: 0.8rem;
   gap: 1rem;
   width: 100%;
+
 `;
 
 export default MyPage;

--- a/src/components/myPage/MyPageModal.jsx
+++ b/src/components/myPage/MyPageModal.jsx
@@ -8,31 +8,32 @@ const MyPageModal = ({ close, nickname, setNickname, setImage, introduce, setInt
   const [file, setFile] = useState(null);
   const [userData, setUserData] = useState(null);
   const myModalRef = useRef(null);
-  useEffect(() => {
-    const authToken = localStorage.getItem('sb-muzurefacnghaayepwdd-auth-token');
 
-    if (authToken) {
+  useEffect(() => {
+    const getUserData = () => {
+      const authToken = localStorage.getItem('sb-muzurefacnghaayepwdd-auth-token');
+      if (!authToken) return console.log('토큰을 찾지 못했습니다.');
+
       try {
         const parsedToken = JSON.parse(authToken);
-        const userId = parsedToken?.user?.id;
-        setUserData(userId);
+        setUserData(parsedToken?.user?.id || null);
       } catch (error) {
         console.error('토큰 파싱 실패:', error);
       }
-    } else {
-      console.log('토큰을 찾지 못했습니다.');
-    }
+    };
+
+    getUserData();
   }, []);
 
   const handleCloseModal = () => {
+    setFile(null);
     close?.();
   };
 
   useOutsideClick(myModalRef, handleCloseModal);
 
-  const handleFileChange = (event) => {
-    setFile(event.target.files[0]);
-  };
+  const handleFileChange = (event) => setFile(event.target.files[0]);
+
   const handleProfile = async () => {
     try {
       if (!userData) {
@@ -55,7 +56,6 @@ const MyPageModal = ({ close, nickname, setNickname, setImage, introduce, setInt
 
         const { data: publicUrlData } = supabase.storage.from('imageFile').getPublicUrl(fileName);
         publicUrl = publicUrlData.publicUrl;
-        console.log(publicUrl);
 
         const { data: updateData, error: updateError } = await supabase
           .from('userinfo')
@@ -93,7 +93,7 @@ const MyPageModal = ({ close, nickname, setNickname, setImage, introduce, setInt
 
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-30 z-50">
-      <div className="h-auto rounded-lg w-[500px] bg-white" ref={myModalRef}>
+      <div className={`h-auto rounded-lg bg-white w-2/3 md:w-auto`} ref={myModalRef}>
         <div className="m-2 flex justify-center items-center">
           <h3>내 정보</h3>
         </div>
@@ -118,7 +118,9 @@ const MyPageModal = ({ close, nickname, setNickname, setImage, introduce, setInt
               style={{ resize: 'none' }}
               value={newIntroduce}
               placeholder={
-                introduce.length > 0 ? '자기소개를 수정하세요 (최대 100자)' : '자기소개를 추가하세요 (최대 100자)'
+                (introduce?.length || 0) > 0
+                  ? '자기소개를 수정하세요 (최대 100자)'
+                  : '자기소개를 추가하세요 (최대 100자)'
               }
               onChange={(e) => setNewIntroduce(e.target.value)}
               id="newIntroduce"
@@ -130,7 +132,7 @@ const MyPageModal = ({ close, nickname, setNickname, setImage, introduce, setInt
               프로필 사진
             </label>
             <input
-              className="px-5 py-2.5 rounded-md m-1.5 font-semibold border"
+              className="px-5 py-2.5 rounded-md m-1.5 font-semibold border text-xs"
               type="file"
               id="profile"
               onChange={handleFileChange}
@@ -147,7 +149,7 @@ const MyPageModal = ({ close, nickname, setNickname, setImage, introduce, setInt
             <button
               className="text-xs px-2 py-1.5 border-none bg-btn-red rounded-md text-white m-1.5 font-semibold cursor-pointer hover:bg-red-400 transition-all"
               type="button"
-              onClick={close}
+              onClick={handleCloseModal}
             >
               닫기
             </button>

--- a/src/components/myPage/UserInfo.jsx
+++ b/src/components/myPage/UserInfo.jsx
@@ -63,24 +63,27 @@ const UserInfo = () => {
       <h3 className="flex gap-2 border-b-2 border-slate-300 text-lg items-center pb-2">
         <RiUser3Line />내 정보
       </h3>
-      <div className="flex rounded-2xl p-4 gap-8 bg-customBackground justify-between items-center">
-        <div className="flex items-center w-[80px] h-[80px]">
-          <img src={image} alt="profile-img" className="rounded-full overflow-hidden w-full h-full" />
+      <div className="flex rounded-2xl p-5 gap-4 bg-customBackground justify-between items-center mt-8 box-border">
+        <div className="flex flex-wrap items-center gap-8 w-[90%]">
+          <div className="flex items-center gap-8">
+            <div className="flex items-center w-[3rem] h-[3rem] rounded-ful overflow-hidden">
+              <img src={image} alt="profile-img" className="rounded-full w-full h-full" />
+            </div>
+
+            <div className="flex flex-col gap-2 text-xs">
+              <p>{nickname} 님 반갑습니다.</p>
+              <p className="text-slate-400">email : {theUser && theUser[0].email}</p>
+              <p className="text-slate-400">성별 : {theUser && theUser[0].gender === 'male' ? '남' : '여'}</p>
+            </div>
+          </div>
+          <div className="flex-1 min-w-[200px]">
+            <p className="text-sm text-gray-400 h-full">
+              {theUser && introduce ? introduce : '자기 소개를 추가해주세요'}
+            </p>
+          </div>
         </div>
 
-        <div className="flex flex-col gap-2 text-xs">
-          <p>{nickname} 님 반갑습니다.</p>
-          <p className="text-slate-400">email : {theUser && theUser[0].email}</p>
-          <p className="text-slate-400">성별 : {theUser && theUser[0].gender === 'male' ? '남' : '여'}</p>
-        </div>
-
-        <div className="flex flex-col flex-grow w-ful h-full">
-          <p className="text-sm text-gray-400 h-full">
-            {theUser && introduce ? introduce : '자기 소개를 추가해주세요'}
-          </p>
-        </div>
-
-        <div className="cursor-pointer">
+        <div className="cursor-pointer flex-grow">
           <HiPencilSquare
             className="w-6 h-6"
             onClick={() => {
@@ -95,7 +98,7 @@ const UserInfo = () => {
               nickname={nickname}
               setNickname={setNickname}
               setImage={setImage}
-              introduce={theUser[0].introduce}
+              introduce={introduce}
               setIntroduce={setIntroduce}
             />
           )}
@@ -104,5 +107,4 @@ const UserInfo = () => {
     </STSection>
   );
 };
-
 export default UserInfo;

--- a/src/layout/sidebarMenus.js
+++ b/src/layout/sidebarMenus.js
@@ -7,26 +7,60 @@ import {
   RiHome2Line
 } from 'react-icons/ri';
 
-export const getSidebarMenus = ({ openModal, navigate, placesCount, hasNewPlaces }) => [
+export const getSidebarMenus = ({ openModal, navigate, hasNewPlaces, resetPlacesNotification }) => [
   { icon: RiSearchLine, text: '검색', onClick: openModal },
   {
     icon: RiGroupLine,
     text: '모임',
     hasAlarm: hasNewPlaces,
-    onClick: () => navigate('/gathering') 
+    onClick: () => {
+      navigate('/gathering');
+      resetPlacesNotification();
+    }
   },
   { icon: RiArrowGoBackLine, text: '뒤로가기', onClick: () => navigate(-1) }
 ];
 
 export const getBottomMenus = ({ navigate, handleSignOut, hasNewContracts }) => [
-  { icon: RiUser3Line, text: '내 계정', onClick: () => navigate('/mypage') },
+  {
+    icon: RiUser3Line,
+    text: '내 계정',
+    hasAlarm: hasNewContracts,
+    onClick: () => {
+      navigate('/mypage');
+    }
+  },
   { icon: RiLogoutBoxRLine, text: '로그아웃', onClick: handleSignOut }
 ];
 
-export const getMobileMenus = ({ navigate, openModal, handleSignOut, placesCount, hasNewPlaces }) => [
+export const getMobileMenus = ({
+  navigate,
+  openModal,
+  handleSignOut,
+  hasNewPlaces,
+  hasNewContracts,
+  resetContractsNotification,
+  resetPlacesNotification
+}) => [
   { icon: RiHome2Line, text: '홈', onClick: () => navigate('/') },
-  { icon: RiGroupLine, text: '모임', onClick: () => navigate('/gathering'), hasAlarm: hasNewPlaces },
+  {
+    icon: RiGroupLine,
+    text: '모임',
+    onClick: () => {
+      navigate('/gathering');
+      resetPlacesNotification();
+    },
+    hasAlarm: hasNewPlaces
+  },
   { icon: RiSearchLine, text: '검색', onClick: openModal },
-  { icon: RiUser3Line, text: '내 계정', onClick: () => navigate('/mypage') },
+  {
+    icon: RiUser3Line,
+    text: '내 계정',
+    hasAlarm: hasNewContracts,
+    onClick: () => {
+      navigate('/mypage');
+      resetContractsNotification();
+    }
+  },
   { icon: RiLogoutBoxRLine, text: '로그아웃', onClick: handleSignOut }
 ];

--- a/src/pages/DetailPage/EditPostModal.jsx
+++ b/src/pages/DetailPage/EditPostModal.jsx
@@ -4,6 +4,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import supabase from '@/supabase/supabaseClient';
 import { exercises } from '@/components/DetailPage/exercises';
 import Select from 'react-select';
+import isMobile from '@/utils/navermap/isMobile';
 const EditPostModal = ({ close, post, postId }) => {
   const [formData, setFormData] = useState({
     gatherName: post?.gather_name || '',
@@ -83,7 +84,7 @@ const EditPostModal = ({ close, post, postId }) => {
   ];
   return (
     <div className="fixed inset-0 flex justify-center items-center bg-black bg-opacity-50">
-      <div className="bg-white p-6 rounded-lg w-1/3">
+      <div className={`bg-white p-6 rounded-lg ${isMobile()? 'w-3/5' : 'w-2/6'}`}>
         <h2 className="text-xl font-semibold mb-4">모임 정보 수정</h2>
         <form
           onSubmit={(e) => {
@@ -137,7 +138,7 @@ const EditPostModal = ({ close, post, postId }) => {
               className="text-xs px-3 py-1.5 border-none bg-btn-blue rounded-md text-white m-1.5 font-semibold cursor-pointer hover:bg-blue-400 transition-all"
               type="submit"
             >
-              수정 완료
+              완료
             </button>
             <button
               onClick={close}

--- a/src/pages/MainPage/Mainpage.jsx
+++ b/src/pages/MainPage/Mainpage.jsx
@@ -141,17 +141,17 @@ function Mainpage({ user = null, contracts = [] }) {
           <input
             type="text"
             id="search-input"
-            className="bg-gray-50 border border-gray-300 text-gray-900 rounded focus:ring-blue-500 focus:border-blue-500 py-[3px] px-2 text-xs flex-grow"
+            className="bg-gray-50 border w-4/5 border-gray-300 text-gray-900 rounded focus:ring-blue-500 focus:border-blue-500 py-[3px] px-2 text-xs"
             ref={searchInputRef}
             placeholder="지번/도로명 주소를 입력해주세요."
           />
           <button
             type="submit"
             id="search-button"
-            className="bg-btn-blue hover:bg-blue-4000 text-white font-bold py-1 px-2 rounded text-xs"
+            className="bg-btn-blue w-1/5 hover:bg-blue-4000 text-white font-bold py-1 px-2 rounded text-xs"
             ref={searchButtonRef}
           >
-            위치검색
+            검색
           </button>
         </form>
         <div id="map01" className="h-full w-full" />

--- a/src/utils/navermap/addressToCoord.js
+++ b/src/utils/navermap/addressToCoord.js
@@ -1,6 +1,6 @@
 import SetInfoWindowContent from '@/components/navermap/SetInfoWindow';
-import swal from '../sweetalert/swal';
 import isMobile from './isMobile';
+import swal, { Swal } from '../sweetalert/swal';
 
 function searchAddressToCoordinate(
   infoWindow,
@@ -29,7 +29,9 @@ function searchAddressToCoordinate(
       }
 
       if (response.v2.meta.totalCount === 0) {
-        swal('error', `검색결과가 없습니다. 결과 ${response.v2.meta.totalCount}건`);
+        if (!Swal.getPopup()) {
+          swal('error', `검색결과가 없습니다. 결과 ${response.v2.meta.totalCount}건`);
+        }
         return;
       }
 

--- a/src/utils/sweetalert/swal.js
+++ b/src/utils/sweetalert/swal.js
@@ -7,5 +7,5 @@ function swal(type, text) {
     icon: type
   });
 }
-
+export { Swal };
 export default swal;

--- a/src/zustand/auth.store.js
+++ b/src/zustand/auth.store.js
@@ -61,10 +61,14 @@ export const useUserStore = create((set) => ({
   },
 
   checkSignIn: async () => {
-    const { data: userData, error: userError } = await supabase.auth.getUser();
-    if (userError) {
-      throw new Error(userError.message);
+    try {
+      const { data, error } = await supabase.auth.getUser();
+      if (error) {
+        throw new Error(error.message);
+      }
+      set({ userData: data.user || null, loading: false, error: null });
+    } catch (error) {
+      set({ userData: null, loading: false, error: `Check sign-in failed: ${error.message}` });
     }
-    set({ userData, loading: false, error: null });
   }
 }));

--- a/src/zustand/placescount.store.js
+++ b/src/zustand/placescount.store.js
@@ -1,7 +1,7 @@
 import supabase from '@/supabase/supabaseClient';
 import { create } from 'zustand';
-
-const fetchContractsCount = async (userId) => {
+import { persist } from 'zustand/middleware';
+const fetchContractsCount = async (userId, set, get) => {
   // 사용자가 만든 장소를 가져옵니다.
   const { data: placesData, error: placesError } = await supabase.from('Places').select('id').eq('created_by', userId);
 
@@ -24,7 +24,9 @@ const fetchContractsCount = async (userId) => {
   if (contractsError) {
     throw new Error(contractsError.message);
   }
-
+  if (count > get().contractsCount) {
+    set({ hasNewContracts: true });
+  }
   return count; // 사용자가 만든 모임에 가입된 총 인원 수를 반환
 };
 
@@ -39,89 +41,121 @@ const fetchPlacesCount = async (userId) => {
   return placesData.length; // 사용자가 만든 장소의 개수를 반환
 };
 
-export const usePlacesCount = create((set, get) => ({
-  placesCount: 0,
-  contractsCount: 0,
-  error: null,
-  hasNewContracts: false,
-  hasNewPlaces: false,
-  startFetching: (userId) => {
-    // 'Contracts' 테이블에서 새로운 멤버가 있는지 확인하는 채널
-    const contractsUpdateChannel = supabase
-      .channel('contracts-update-channel')
-      .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'Contracts' }, async (payload) => {
-        // 새로운 계약이 추가될 때마다 사용자가 만든 모임에 가입된 인원 수를 갱신합니다.
-        if (payload.new.place_id) {
+export const usePlacesCount = create(
+  persist(
+    (set, get) => ({
+      placesCount: 0,
+      contractsCount: 0,
+      error: null,
+      hasNewContracts: false,
+      hasNewPlaces: false,
+      startFetching: (userId) => {
+        const fetchData = async () => {
           try {
-            const newContractsCount = await fetchContractsCount(userId);
-            set({ contractsCount: newContractsCount, hasNewContracts: true });
+            const contractsCount = await fetchContractsCount(userId, set, get);
+            set({ contractsCount });
           } catch (error) {
             set({ error: error.message });
           }
+        };
+
+        // 초기 데이터 로드
+        fetchData();
+        // 'Contracts' 테이블에서 새로운 멤버가 있는지 확인하는 채널
+        const contractsInsertChannel = supabase
+          .channel('contracts-insert-channel')
+          .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'Contracts' }, async (payload) => {
+            // 모임장이 가입을 승인하면 일반 회원에게 알림을 보냅니다.
+            //모임장에 갈 알림
+            //일단 이벤트 발생한 내용중 payload.new.place_id를 가져와 모임장이 누군지 확인하기
+            //Places테이블에서 payload.new.place_id와 created_by 일치한거를 찾고
+            //찾은 결과물이 모임장이니 현재로그인한 사용자가 모임장인지 구분
+            //현재로그인한 사람이 모임장이면 알림 true  아니면 동작하지않는다
+
+            if (payload.new.status === 'approved' || payload.new.status === 'pending') {
+              try {
+                const { data: ownerId, error: ownerIdError } = await supabase
+                  .from('Places')
+                  .select('*')
+                  .eq('id', payload.new.place_id);
+
+                const { data, error } = await supabase.auth.getUser();
+                if (error || !data?.user) {
+                  console.error('로그인된 사용자 정보를 가져올 수 없습니다.');
+                  return;
+                }
+
+                const userId = data.user.id; //현재 로그인중인 사용자가 모임장인지 체크
+                if (ownerIdError) {
+                  throw new Error(ownerIdError.message);
+                }
+                if (userId === ownerId[0].created_by) {
+                  set({ hasNewContracts: true });
+                }
+              } catch (error) {
+                set({ error: error.message });
+              }
+            }
+          })
+          .subscribe();
+
+        const contractsUpdateChannel = supabase
+          .channel('contracts-update-channel')
+          .on('postgres_changes', { event: 'UPDATE', schema: 'public', table: 'Contracts' }, async (payload) => {
+            if (payload.new.status === 'approved' || payload.new.status === 'rejected') {
+              try {
+                const { data, error } = await supabase.auth.getUser();
+                if (error || !data?.user) {
+                  console.error('로그인된 사용자 정보를 가져올 수 없습니다.');
+                  return;
+                }
+                const userId = data.user.id; //현재 로그인중인 사용자가 모임장인지 체크
+                if (userId === payload.new.user_id) {
+                  set({ hasNewContracts: true });
+                }
+              } catch (error) {
+                set({ error: error.message });
+              }
+            }
+          })
+          .subscribe();
+
+        // 'Places' 테이블에서 새로운 장소가 등록되었는지 확인하는 채널
+        const placesUpdateChannel = supabase
+          .channel('places-update-channel')
+          .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'Places' }, async () => {
+            // 새로운 장소가 추가될 때마다 사용자가 만든 장소의 갯수를 갱신합니다.
+            try {
+              const newPlacesCount = await fetchPlacesCount(userId);
+              set({ placesCount: newPlacesCount, hasNewPlaces: true });
+            } catch (error) {
+              set({ error: error.message });
+            }
+          })
+          .subscribe();
+
+        // set({ contractsUpdateChannel, placesUpdateChannel });
+      },
+      stopFetching: () => {
+        const state = get();
+        if (state.contractsUpdateChannel) {
+          supabase.removeChannel(state.contractsUpdateChannel);
         }
-      })
-      .subscribe();
-
-    // 'Places' 테이블에서 새로운 장소가 등록되었는지 확인하는 채널
-    const placesUpdateChannel = supabase
-      .channel('places-update-channel')
-      .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'Places' }, async () => {
-        // 새로운 장소가 추가될 때마다 사용자가 만든 장소의 갯수를 갱신합니다.
-        try {
-          const newPlacesCount = await fetchPlacesCount(userId);
-          set({ placesCount: newPlacesCount, hasNewPlaces: true });
-        } catch (error) {
-          set({ error: error.message });
+        if (state.placesUpdateChannel) {
+          supabase.removeChannel(state.placesUpdateChannel);
         }
-      })
-      .subscribe();
-
-    set({ contractsUpdateChannel, placesUpdateChannel });
-  },
-  stopFetching: (type) => {
-    const state = get();
-    const updates = {};
-    if (state.contractsUpdateChannel && type === 'contracts') {
-      supabase.removeChannel(state.contractsUpdateChannel);
-      updates.contractsUpdateChannel = null;
-      updates.hasNewContracts = false;
+        set({ contractsUpdateChannel: null, placesUpdateChannel: null, hasNewContracts: false, hasNewPlaces: false });
+      },
+      resetContractsNotification: () => {
+        set({ hasNewContracts: false });
+      },
+      resetPlacesNotification: () => {
+        set({ hasNewPlaces: false });
+      }
+    }),
+    {
+      name: 'places-count-storage', // 로컬스토리지에 저장될 이름
+      getStorage: () => sessionStorage // localStorage 사용 (sessionStorage로 변경 가능)
     }
-    if (state.placesUpdateChannel && type === 'places') {
-      supabase.removeChannel(state.placesUpdateChannel);
-      updates.placesUpdateChannel = null;
-      updates.hasNewPlaces = false;
-    }
-    if (Object.keys(updates).length > 0) {
-      set(updates);
-    }
-  },
-
-  // getPreviousCount: async (userId) => {
-  //   try {
-  //     const { data, error } = await supabase.from('userinfo').select('*').eq('id', userId);
-  //     if (error) {
-  //       throw new Error(error.message);
-  //     }
-  //     let prev = data[0].total_applicant;
-  //     set({ previousCount: prev });
-  //   } catch (error) {
-  //     console.log('getPreviousCount함수오류', error);
-  //   }
-  // },
-  resetContractsNotification: () => set({ hasNewContracts: false }),
-  resetPlacesNotification: () => set({ hasNewPlaces: false })
-  // updateApplicant: async (userId, newTotalApplicant) => {
-  //   try {
-  //     const { data, error } = await supabase
-  //       .from('userinfo')
-  //       .update({ total_applicant: newTotalApplicant })
-  //       .eq('id', userId);
-
-  //     if (error) {
-  //       throw new Error(error.message);
-  //     }
-  //   } catch (error) {
-  //     console.error('Error updating total applicant:', error.message);
-  //   }
-  // }
-}));
+  )
+);


### PR DESCRIPTION
[fix]:CreateGroupModal.jsx | map메서드 사용후 요소에 key값누락으로 index를 추가함 
[update]: ClubInfo.jsx | 현재 승인상태 status를 추가해 멤버가 현재 어떤 승인 상태인지 확인 가능하게 수정 
[update]: ClubList.jsx | 기존 리스트 형태로만 보이던 모임정보를 현재 탭으로 전환해서 리스트 확인할 수 있도록 수정 
[css] : MyPage.jsx | height설정으로인해 리스트 일부가 짤리는 현상확인되여 높이조절 다시진행함 
[css] : MypageModal.jsx | width 값을 고정 PX로 부여된부분을 반응형으로 변경 
[css] : UserInfo.jsx | 고정 width 값 반응형으로 변경 및 잘 못된 props를 수정 [
fix]: sidebarMenus.js | 불필요한 파라미터 삭제하고 real time으로 갱신된 알림을 리셋함수추가 적용 
[update]: DetailPost.jsx | 기존에 없었던 useQuery의 isPending,isError를 보충 및 refetch를 추가적용 & 탭방식으로 변경해 가입된 멤버리스트와 승인대기리스트를 나눔 & 회원이 모임 참여거절됬을경우 안내 멘트 추가 
[css]: EditPostModal.jsx | isMobile함수를 추가해 모바일때와 아닐떄를 구분하여 css 구현 & 고정 px값을 반응형으로 변경 [css] Mainpage.jsx | 위치검색 css부분 수정해서 모바일에서 동일한 UI보일수 있도록 수정 
[fix]: addressToCoord.js | 검색 결과 없을경우 Sweet alert이 여러번 팝업되는증상 조치(이미 팝업된 alert이 있다면 다시 안띄우기) 
[update]: placescount.store.js | Contracts 테이블 채널을 구독해 update,insert 이벤트 발생 시 hasNewContracts를 true로 변경 & Places채널에 insert이벤트 감지해 hasNewPlaces를 true로 하고 placesCount를 갱신 & 브라우저를 새로고침할 경우 hasNewContracts가 리셋되여 이전값을 참조하는데 이는 zustand특성상인 원인으로 파악하여 persist를 적용해 채널을 구독하되 값들은 로컬스토리지 or 세션스토리지에 저장통해 새로고침하여도 이상증상없이 정상적으로 알림 구동 확인